### PR TITLE
Add authenticated layout route for settings page

### DIFF
--- a/src/0-routes/_authenticated.tsx
+++ b/src/0-routes/_authenticated.tsx
@@ -1,0 +1,29 @@
+import { createFileRoute, Outlet, useNavigate } from "@tanstack/react-router";
+import { useConvexAuth } from "convex/react";
+import { Loader2 } from "lucide-react";
+import { useEffect } from "react";
+
+export const Route = createFileRoute("/_authenticated")({
+	component: AuthenticatedLayout,
+});
+
+function AuthenticatedLayout() {
+	const { isAuthenticated, isLoading } = useConvexAuth();
+	const navigate = useNavigate();
+
+	useEffect(() => {
+		if (!isLoading && !isAuthenticated) {
+			navigate({ to: "/signin" });
+		}
+	}, [isLoading, isAuthenticated, navigate]);
+
+	if (isLoading || !isAuthenticated) {
+		return (
+			<div className="flex items-center justify-center py-20">
+				<Loader2 className="size-8 animate-spin text-muted-foreground" />
+			</div>
+		);
+	}
+
+	return <Outlet />;
+}

--- a/src/0-routes/_authenticated/settings.tsx
+++ b/src/0-routes/_authenticated/settings.tsx
@@ -1,10 +1,5 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import {
-	Authenticated,
-	Unauthenticated,
-	useMutation,
-	useQuery,
-} from "convex/react";
+import { createFileRoute } from "@tanstack/react-router";
+import { useMutation, useQuery } from "convex/react";
 import {
 	AlertTriangle,
 	Check,
@@ -27,38 +22,11 @@ import { Input } from "@/1-components/ui/input";
 import { Label } from "@/1-components/ui/label";
 import { api } from "~/_generated/api";
 
-export const Route = createFileRoute("/settings")({
+export const Route = createFileRoute("/_authenticated/settings")({
 	component: SettingsPage,
 });
 
 function SettingsPage() {
-	return (
-		<>
-			<Unauthenticated>
-				<UnauthenticatedSettings />
-			</Unauthenticated>
-			<Authenticated>
-				<AuthenticatedSettings />
-			</Authenticated>
-		</>
-	);
-}
-
-function UnauthenticatedSettings() {
-	const navigate = useNavigate();
-	return (
-		<div className="flex flex-col items-center justify-center gap-4 py-20">
-			<Key className="size-12 text-muted-foreground" />
-			<h2 className="text-xl font-semibold">Sign in required</h2>
-			<p className="text-muted-foreground">
-				You need to sign in to manage your settings.
-			</p>
-			<Button onClick={() => navigate({ to: "/signin" })}>Sign in</Button>
-		</div>
-	);
-}
-
-function AuthenticatedSettings() {
 	const uid = useId();
 	const credentials = useQuery(api.tacticus.credentials.get);
 	const saveMutation = useMutation(api.tacticus.credentials.save);

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,17 +10,17 @@
 
 import { Route as rootRouteImport } from './0-routes/__root'
 import { Route as SigninRouteImport } from './0-routes/signin'
-import { Route as SettingsRouteImport } from './0-routes/settings'
+import { Route as AuthenticatedRouteImport } from './0-routes/_authenticated'
 import { Route as IndexRouteImport } from './0-routes/index'
+import { Route as AuthenticatedSettingsRouteImport } from './0-routes/_authenticated/settings'
 
 const SigninRoute = SigninRouteImport.update({
   id: '/signin',
   path: '/signin',
   getParentRoute: () => rootRouteImport,
 } as any)
-const SettingsRoute = SettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
+const AuthenticatedRoute = AuthenticatedRouteImport.update({
+  id: '/_authenticated',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -28,34 +28,45 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthenticatedSettingsRoute = AuthenticatedSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/settings': typeof SettingsRoute
   '/signin': typeof SigninRoute
+  '/settings': typeof AuthenticatedSettingsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/settings': typeof SettingsRoute
   '/signin': typeof SigninRoute
+  '/settings': typeof AuthenticatedSettingsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
-  '/settings': typeof SettingsRoute
+  '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/signin': typeof SigninRoute
+  '/_authenticated/settings': typeof AuthenticatedSettingsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/settings' | '/signin'
+  fullPaths: '/' | '/signin' | '/settings'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/settings' | '/signin'
-  id: '__root__' | '/' | '/settings' | '/signin'
+  to: '/' | '/signin' | '/settings'
+  id:
+    | '__root__'
+    | '/'
+    | '/_authenticated'
+    | '/signin'
+    | '/_authenticated/settings'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
-  SettingsRoute: typeof SettingsRoute
+  AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
   SigninRoute: typeof SigninRoute
 }
 
@@ -68,11 +79,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SigninRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/settings': {
-      id: '/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof SettingsRouteImport
+    '/_authenticated': {
+      id: '/_authenticated'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof AuthenticatedRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -82,12 +93,31 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_authenticated/settings': {
+      id: '/_authenticated/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof AuthenticatedSettingsRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
   }
 }
 
+interface AuthenticatedRouteChildren {
+  AuthenticatedSettingsRoute: typeof AuthenticatedSettingsRoute
+}
+
+const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
+  AuthenticatedSettingsRoute: AuthenticatedSettingsRoute,
+}
+
+const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
+  AuthenticatedRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-  SettingsRoute: SettingsRoute,
+  AuthenticatedRoute: AuthenticatedRouteWithChildren,
   SigninRoute: SigninRoute,
 }
 export const routeTree = rootRouteImport


### PR DESCRIPTION
## Summary
- Add `_authenticated` layout route that redirects unauthenticated users to `/signin`
- Move `/settings` under the `/_authenticated` layout, replacing inline `Authenticated`/`Unauthenticated` component checks
- Simplify settings page by removing auth-gating boilerplate

## Test plan
- [x] Visit `/settings` while logged out — should redirect to `/signin`
- [x] Sign in, then visit `/settings` — should load the settings page normally
- [x] Verify `build-ci` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Settings page now routed through an authentication verification layer
  * Route hierarchy reorganized to separate authenticated and public user sections
  * Improved navigation structure with enhanced authentication state management during transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->