### PR TITLE
Add image normalization script

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
         "eslint-plugin-testing-library": "^7.15.4",
         "happy-dom": "^20.6.1",
         "knip": "^5.83.1",
+        "sharp": "^0.34.5",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.55.0",
         "vite": "^7.3.1",
@@ -1538,7 +1539,7 @@
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
-    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
@@ -1780,6 +1781,12 @@
 
     "zustand": ["zustand@5.0.11", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg=="],
 
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-create-class-features-plugin/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
     "@clerk/shared/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
     "@cloudflare/vite-plugin/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
@@ -1858,8 +1865,6 @@
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
     "@typescript-eslint/utils/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.49.0", "", { "dependencies": { "@typescript-eslint/types": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0" } }, "sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg=="],
 
     "@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.49.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.49.0", "@typescript-eslint/tsconfig-utils": "8.49.0", "@typescript-eslint/types": "8.49.0", "@typescript-eslint/visitor-keys": "8.49.0", "debug": "^4.3.4", "minimatch": "^9.0.4", "semver": "^7.6.0", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.0.0" } }, "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA=="],
@@ -1920,8 +1925,6 @@
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
     "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "tsconfig-paths-webpack-plugin/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -1975,8 +1978,6 @@
     "@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.49.0", "", { "dependencies": { "@typescript-eslint/types": "8.49.0", "eslint-visitor-keys": "^4.2.1" } }, "sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA=="],
 
     "@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@typescript-eslint/utils/@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -9,7 +9,8 @@
 		"src/5-assets/factions/index.ts", // factions pipeline — not yet wired into UI
 		"src/5-assets/guild-war/index.ts", // guild war pipeline — not yet wired into UI
 		"src/5-assets/le-battles/index.ts", // LE battles pipeline — not yet wired into UI
-		"src/5-assets/legacy-json/compare-with-active-pipelines.ts" // dev utility script
+		"src/5-assets/legacy-json/compare-with-active-pipelines.ts", // dev utility script
+		"scripts/**/*" // dev utility scripts (normalize-images, etc.)
 	],
 	"ignoreDependencies": ["@base-ui/react"], // false positive
 	"ignoreExportsUsedInFile": true,

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
 		"check": "bun run biomePrecheck && biome check && eslint .",
 		"fix": "bun run biomePrecheck && biome check --fix && eslint --fix .",
 		"build-ci": "bun run fix && tsc --noEmit && bun run build",
-		"knip": "knip"
+		"knip": "knip",
+		"normalize-images": "bun run scripts/normalize-images.ts",
+		"normalize-images:fix": "bun run scripts/normalize-images.ts --fix"
 	},
 	"dependencies": {
 		"@auth/core": "0.41.1",
@@ -79,6 +81,7 @@
 		"eslint-plugin-testing-library": "^7.15.4",
 		"happy-dom": "^20.6.1",
 		"knip": "^5.83.1",
+		"sharp": "^0.34.5",
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.55.0",
 		"vite": "^7.3.1",

--- a/scripts/normalize-images.ts
+++ b/scripts/normalize-images.ts
@@ -1,0 +1,233 @@
+// biome-ignore-all lint/correctness/noNodejsModules: CLI script runs in Bun, not browser
+// biome-ignore-all lint/performance/noAwaitInLoops: sequential I/O is intentional for clear reporting
+// biome-ignore-all lint/correctness/noUndeclaredVariables: Bun global is available at runtime
+
+/**
+ * Image normalization script.
+ *
+ * Scans all image asset folders and ensures every PNG matches the expected
+ * dimensions for its category. Images that don't match are resized to fit
+ * within the target canvas (preserving aspect ratio) and centered on a
+ * transparent background.
+ *
+ * Usage:
+ *   bun run normalize-images          # dry-run — reports mismatches
+ *   bun run normalize-images --fix    # resize mismatched images in-place
+ */
+
+import path from "node:path";
+import { Glob } from "bun";
+import sharp from "sharp";
+
+const ASSETS_ROOT = path.resolve(import.meta.dir, "../src/5-assets");
+
+/** Target dimensions for each image folder. */
+const RULES: Array<{
+	label: string;
+	glob: string;
+	width: number;
+	height: number;
+}> = [
+	{
+		label: "Rank icons",
+		glob: "images/tacticus/ranks/*.png",
+		width: 64,
+		height: 64,
+	},
+	{
+		label: "Alliance badges",
+		glob: "images/tacticus/badges/*.png",
+		width: 55,
+		height: 55,
+	},
+	{
+		label: "Rarity icons",
+		glob: "images/tacticus/rarity/*.png",
+		width: 44,
+		height: 50,
+	},
+	{
+		label: "Rarity frames",
+		glob: "images/tacticus/rarity_frames/*.png",
+		width: 202,
+		height: 267,
+	},
+	{
+		label: "Misc icons (XP books, energy)",
+		glob: "images/tacticus/icons/*.png",
+		width: 64,
+		height: 64,
+	},
+	{
+		label: "Faction icons",
+		glob: "snowprint_assets/factions/*.png",
+		width: 64,
+		height: 64,
+	},
+];
+
+/**
+ * Campaigns have multiple size tiers (classic 55x55, newer 96x96, extremis 120x96).
+ * We check whether an image matches any allowed tier and normalize to the nearest one.
+ */
+const CAMPAIGN_TIERS = [
+	{ width: 55, height: 55 },
+	{ width: 96, height: 96 },
+	{ width: 120, height: 96 },
+] as const;
+
+const fix = Bun.argv.includes("--fix");
+
+let totalChecked = 0;
+let totalMismatched = 0;
+let totalFixed = 0;
+
+async function resizeImage(
+	filePath: string,
+	targetW: number,
+	targetH: number,
+): Promise<void> {
+	const resized = await sharp(filePath)
+		.resize(targetW, targetH, {
+			fit: "contain",
+			background: { r: 0, g: 0, b: 0, alpha: 0 },
+		})
+		.png()
+		.toBuffer();
+	await Bun.write(filePath, resized);
+}
+
+async function collectFiles(globStr: string): Promise<string[]> {
+	const g = new Glob(globStr);
+	const files: string[] = [];
+	for await (const match of g.scan({ cwd: ASSETS_ROOT })) {
+		files.push(path.join(ASSETS_ROOT, match));
+	}
+	return files.sort();
+}
+
+async function getImageSizes(
+	files: string[],
+): Promise<Array<{ file: string; w: number; h: number }>> {
+	const results = await Promise.all(
+		files.map(async (file) => {
+			const meta = await sharp(file).metadata();
+			return { file, w: meta.width ?? 0, h: meta.height ?? 0 };
+		}),
+	);
+	return results;
+}
+
+async function fixImages(
+	images: Array<{
+		file: string;
+		w: number;
+		h: number;
+		targetW: number;
+		targetH: number;
+	}>,
+): Promise<number> {
+	let fixed = 0;
+	for (const m of images) {
+		const rel = path.relative(ASSETS_ROOT, m.file);
+		if (fix) {
+			await resizeImage(m.file, m.targetW, m.targetH);
+			fixed++;
+			console.log(
+				`    FIXED  ${rel} (was ${m.w}x${m.h} → ${m.targetW}x${m.targetH})`,
+			);
+		} else {
+			console.log(
+				`    NEEDS FIX  ${rel} (${m.w}x${m.h} → should be ${m.targetW}x${m.targetH})`,
+			);
+		}
+	}
+	return fixed;
+}
+
+async function checkFolder(rule: {
+	label: string;
+	glob: string;
+	width: number;
+	height: number;
+}): Promise<void> {
+	const files = await collectFiles(rule.glob);
+
+	if (files.length === 0) {
+		console.log(`  ${rule.label}: no files found (${rule.glob})`);
+		return;
+	}
+
+	const sizes = await getImageSizes(files);
+	totalChecked += files.length;
+
+	const mismatched = sizes
+		.filter((s) => s.w !== rule.width || s.h !== rule.height)
+		.map((s) => ({ ...s, targetW: rule.width, targetH: rule.height }));
+
+	if (mismatched.length === 0) {
+		console.log(
+			`  ${rule.label}: ${files.length} files OK (${rule.width}x${rule.height})`,
+		);
+		return;
+	}
+
+	totalMismatched += mismatched.length;
+	console.log(
+		`  ${rule.label}: ${mismatched.length}/${files.length} need resizing → ${rule.width}x${rule.height}`,
+	);
+	totalFixed += await fixImages(mismatched);
+}
+
+async function checkCampaigns(): Promise<void> {
+	const files = await collectFiles("images/tacticus/campaigns/*.png");
+
+	if (files.length === 0) {
+		console.log("  Campaigns: no files found");
+		return;
+	}
+
+	const sizes = await getImageSizes(files);
+	totalChecked += files.length;
+
+	const mismatched = sizes
+		.filter(
+			(s) => !CAMPAIGN_TIERS.some((t) => s.w === t.width && s.h === t.height),
+		)
+		.map((s) => {
+			const area = s.w * s.h;
+			const nearest = CAMPAIGN_TIERS.reduce((best, tier) => {
+				const tArea = tier.width * tier.height;
+				const bArea = best.width * best.height;
+				return Math.abs(area - tArea) < Math.abs(area - bArea) ? tier : best;
+			});
+			return { ...s, targetW: nearest.width, targetH: nearest.height };
+		});
+
+	if (mismatched.length === 0) {
+		console.log(
+			`  Campaigns: ${files.length} files OK (${CAMPAIGN_TIERS.map((t) => `${t.width}x${t.height}`).join(" or ")})`,
+		);
+		return;
+	}
+
+	totalMismatched += mismatched.length;
+	console.log(
+		`  Campaigns: ${mismatched.length}/${files.length} need resizing`,
+	);
+	totalFixed += await fixImages(mismatched);
+}
+
+console.log(fix ? "Normalizing images...\n" : "Checking image sizes...\n");
+
+for (const rule of RULES) {
+	await checkFolder(rule);
+}
+await checkCampaigns();
+
+console.log(`\nChecked ${totalChecked} images. ${totalMismatched} mismatched.`);
+if (fix) {
+	console.log(`Fixed ${totalFixed} images.`);
+} else if (totalMismatched > 0) {
+	console.log("Run with --fix to resize them.");
+}


### PR DESCRIPTION
## Summary
- Bun + sharp script (`scripts/normalize-images.ts`) that checks all image asset folders against their target dimensions
- `bun run normalize-images` — dry-run audit reporting mismatched images
- `bun run normalize-images:fix` — auto-resize mismatched images in-place (contain + transparent padding)
- Covers ranks, badges, rarity icons/frames, misc icons, faction icons, and campaigns (multi-tier)

## Test plan
- [ ] `bun run normalize-images` reports all 107 images OK
- [ ] Add an oversized image to any folder → script reports it as needing fix
- [ ] `bun run normalize-images:fix` resizes it to the correct dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image normalization commands to validate and optionally resize PNG assets to predefined target dimensions, with dry-run and --fix modes.
  * Campaign assets normalized to nearest supported size tiers to ensure consistency.

* **Chores**
  * Added image processing dependency for resizing.
  * Updated configuration to ignore development utility scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->