### PR TITLE
Move sync button to global top bar header

### DIFF
--- a/src/0-routes/_authenticated/campaign-progression.tsx
+++ b/src/0-routes/_authenticated/campaign-progression.tsx
@@ -1,21 +1,19 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useAction, useQuery } from "convex/react";
+import { useQuery } from "convex/react";
 import {
 	AlertTriangle,
 	ChevronDown,
 	Loader2,
 	Map as MapIcon,
-	RefreshCw,
 	TrendingUp,
 	Unlock,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { CampaignIcon } from "@/1-components/general/CampaignIcon.tsx";
 import { CharacterIcon } from "@/1-components/general/CharacterIcon.tsx";
 import { EnergyIcon } from "@/1-components/general/EnergyIcon.tsx";
 import { MaterialIcon } from "@/1-components/general/MaterialIcon.tsx";
 import { Badge } from "@/1-components/ui/badge.tsx";
-import { Button } from "@/1-components/ui/button.tsx";
 import { useCampaignProgressStore } from "@/3-hooks/useCampaignProgressStore.ts";
 import { usePlayerDataStore } from "@/3-hooks/usePlayerDataStore.ts";
 import {
@@ -36,13 +34,9 @@ export const Route = createFileRoute("/_authenticated/campaign-progression")({
 
 function CampaignProgressionPage() {
 	const goals = useQuery(api.goals.list);
-	const getPlayerData = useAction(api.tacticus.actions.getPlayerData);
 
 	const campaignProgressApi = usePlayerDataStore((s) => s.campaignProgress);
 	const inventory = usePlayerDataStore((s) => s.inventory);
-	const syncing = usePlayerDataStore((s) => s.syncing);
-	const setPlayerData = usePlayerDataStore((s) => s.setPlayerData);
-	const setSyncing = usePlayerDataStore((s) => s.setSyncing);
 
 	const persistedProgress = useCampaignProgressStore((s) => s.progress);
 
@@ -103,29 +97,6 @@ function CampaignProgressionPage() {
 		};
 	}, [goals, getTypedGoals, getMergedProgress, inventory]);
 
-	const handleSync = useCallback(async () => {
-		setSyncing(true);
-		try {
-			const response = await getPlayerData();
-			if (response?.player?.units) {
-				setPlayerData(response);
-			}
-		} catch {
-			// Sync failed
-		} finally {
-			setSyncing(false);
-		}
-	}, [getPlayerData, setPlayerData, setSyncing]);
-
-	// Auto-sync on mount
-	const didAutoSync = useRef(false);
-	useEffect(() => {
-		if (!didAutoSync.current) {
-			didAutoSync.current = true;
-			void handleSync();
-		}
-	}, [handleSync]);
-
 	const isLoading = goals === undefined;
 	const upgradeRankCount =
 		goals?.filter((g) => g.type === PersonalGoalType.UpgradeRank).length ?? 0;
@@ -133,31 +104,11 @@ function CampaignProgressionPage() {
 	return (
 		<div className="space-y-6">
 			{/* Header */}
-			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-				<div>
-					<div className="flex items-center gap-2">
-						<h1 className="text-2xl font-bold tracking-tight">
-							Campaign Planner
-						</h1>
-					</div>
-					<p className="text-muted-foreground">
-						Find the next campaign nodes to beat for the biggest farming
-						benefit.
-					</p>
-				</div>
-				<div className="flex items-center gap-2">
-					<Button
-						variant="outline"
-						size="sm"
-						onClick={handleSync}
-						disabled={syncing}
-					>
-						<RefreshCw className={`size-4 ${syncing ? "animate-spin" : ""}`} />
-						<span className="hidden sm:inline">
-							{syncing ? "Syncing..." : "Sync"}
-						</span>
-					</Button>
-				</div>
+			<div>
+				<h1 className="text-2xl font-bold tracking-tight">Campaign Planner</h1>
+				<p className="text-muted-foreground">
+					Find the next campaign nodes to beat for the biggest farming benefit.
+				</p>
 			</div>
 
 			{/* Content */}

--- a/src/0-routes/_authenticated/campaigns.tsx
+++ b/src/0-routes/_authenticated/campaigns.tsx
@@ -1,9 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useAction } from "convex/react";
-import { RefreshCw } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo } from "react";
 import { CampaignProgressCard } from "@/1-components/general/CampaignProgressCard.tsx";
-import { Button } from "@/1-components/ui/button.tsx";
 import { useCampaignProgressStore } from "@/3-hooks/useCampaignProgressStore.ts";
 import { usePlayerDataStore } from "@/3-hooks/usePlayerDataStore.ts";
 import {
@@ -13,8 +10,6 @@ import {
 	getUnlockedNodeCount,
 } from "@/4-lib/general/campaign-data.ts";
 import type { Campaign } from "@/4-lib/general/constants.ts";
-// biome-ignore lint/correctness/useImportExtensions: Convex generated .js file
-import { api } from "~/_generated/api";
 
 export const Route = createFileRoute("/_authenticated/campaigns")({
 	component: CampaignsPage,
@@ -31,13 +26,7 @@ interface CampaignGroup {
 }
 
 function CampaignsPage() {
-	const getPlayerData = useAction(api.tacticus.actions.getPlayerData);
-
 	const campaignProgress = usePlayerDataStore((s) => s.campaignProgress);
-	const syncing = usePlayerDataStore((s) => s.syncing);
-	const lastSyncedAt = usePlayerDataStore((s) => s.lastSyncedAt);
-	const setPlayerData = usePlayerDataStore((s) => s.setPlayerData);
-	const setSyncing = usePlayerDataStore((s) => s.setSyncing);
 
 	const persistedProgress = useCampaignProgressStore((s) => s.progress);
 	const mergeFromApi = useCampaignProgressStore((s) => s.mergeFromApi);
@@ -50,29 +39,6 @@ function CampaignsPage() {
 			mergeFromApi(campaignProgress);
 		}
 	}, [campaignProgress, mergeFromApi]);
-
-	const handleSync = useCallback(async () => {
-		setSyncing(true);
-		try {
-			const response = await getPlayerData();
-			if (response?.player?.units) {
-				setPlayerData(response);
-			}
-		} catch {
-			// Sync failed
-		} finally {
-			setSyncing(false);
-		}
-	}, [getPlayerData, setPlayerData, setSyncing]);
-
-	// Auto-sync on mount only if store has no data
-	const didAutoSync = useRef(false);
-	useEffect(() => {
-		if (!didAutoSync.current && !lastSyncedAt) {
-			didAutoSync.current = true;
-			void handleSync();
-		}
-	}, [handleSync, lastSyncedAt]);
 
 	// Build grouped campaign data using persisted progress
 	const { mainGroups, eventGroups } = useMemo(() => {
@@ -121,26 +87,11 @@ function CampaignsPage() {
 	return (
 		<div className="space-y-6">
 			{/* Header */}
-			<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-				<div>
-					<h1 className="text-2xl font-bold tracking-tight">Campaigns</h1>
-					<p className="text-muted-foreground">
-						Track your campaign progression across all chapters.
-					</p>
-				</div>
-
-				<Button
-					variant="outline"
-					size="sm"
-					onClick={handleSync}
-					disabled={syncing}
-					title="Sync with Tacticus API"
-				>
-					<RefreshCw className={`size-4 ${syncing ? "animate-spin" : ""}`} />
-					<span className="hidden sm:inline">
-						{syncing ? "Syncing..." : "Sync"}
-					</span>
-				</Button>
+			<div>
+				<h1 className="text-2xl font-bold tracking-tight">Campaigns</h1>
+				<p className="text-muted-foreground">
+					Track your campaign progression across all chapters.
+				</p>
 			</div>
 
 			{/* Content */}

--- a/src/0-routes/_authenticated/goals.tsx
+++ b/src/0-routes/_authenticated/goals.tsx
@@ -1,10 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useAction, useMutation, useQuery } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import {
 	LayoutGrid,
 	Loader2,
 	Palette,
-	RefreshCw,
 	Settings,
 	Table,
 	Target,
@@ -195,8 +194,6 @@ function GoalsPage() {
 	const removeAllGoals = useMutation(api.goals.removeAll);
 	const updateGoal = useMutation(api.goals.update);
 	const reorderGoals = useMutation(api.goals.reorder);
-	const getPlayerData = useAction(api.tacticus.actions.getPlayerData);
-
 	const importGoals = useMutation(api.goals.importBatch);
 
 	// Shared player data store (roster, campaign progress, inventory)
@@ -205,8 +202,6 @@ function GoalsPage() {
 	const inventory = usePlayerDataStore((s) => s.inventory);
 	const syncing = usePlayerDataStore((s) => s.syncing);
 	const lastSyncedAt = usePlayerDataStore((s) => s.lastSyncedAt);
-	const setPlayerData = usePlayerDataStore((s) => s.setPlayerData);
-	const setSyncing = usePlayerDataStore((s) => s.setSyncing);
 
 	const [editingGoal, setEditingGoal] = useState<{
 		goalId: string;
@@ -522,33 +517,20 @@ function GoalsPage() {
 		[goals, reorderGoals],
 	);
 
-	const handleSync = useCallback(async () => {
-		setSyncing(true);
-		try {
-			const response = await getPlayerData();
-			if (response?.player?.units) {
-				setPlayerData(response);
-			}
-		} catch {
-			// Sync failed — user likely hasn't configured API keys in settings
-		} finally {
-			setSyncing(false);
-		}
-	}, [getPlayerData, setPlayerData, setSyncing]);
-
-	// Auto-fetch roster on mount only if store has no data.
-	// When the initial sync completes (success or failure), mark initialSyncDone
-	// so estimate/daily-raids computations can begin with real data.
-	const didAutoSync = useRef(false);
+	// Wait for initial data sync (triggered by SyncButton in header) before
+	// computing estimates/daily-raids so they use real inventory data.
+	const hasSyncStarted = useRef(lastSyncedAt !== null);
 	useEffect(() => {
-		if (!didAutoSync.current && !lastSyncedAt) {
-			didAutoSync.current = true;
-			void handleSync().finally(() => setInitialSyncDone(true));
-		} else if (!initialSyncDone && lastSyncedAt !== null) {
-			// Data already available from a previous navigation — ready immediately
+		if (initialSyncDone) return;
+		if (lastSyncedAt !== null) {
+			setInitialSyncDone(true);
+		} else if (syncing) {
+			hasSyncStarted.current = true;
+		} else if (hasSyncStarted.current) {
+			// Sync started and ended without success — proceed with empty data
 			setInitialSyncDone(true);
 		}
-	}, [handleSync, lastSyncedAt, initialSyncDone]);
+	}, [lastSyncedAt, syncing, initialSyncDone]);
 
 	const handleImport = useCallback(
 		async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -645,22 +627,6 @@ function GoalsPage() {
 				<div className="flex flex-wrap items-center gap-2">
 					{goalCount > 0 && (
 						<>
-							{/* Sync */}
-							<Button
-								variant="outline"
-								size="sm"
-								onClick={handleSync}
-								disabled={syncing}
-								title="Sync with Tacticus API"
-							>
-								<RefreshCw
-									className={`size-4 ${syncing ? "animate-spin" : ""}`}
-								/>
-								<span className="hidden sm:inline">
-									{syncing ? "Syncing..." : "Sync"}
-								</span>
-							</Button>
-
 							{/* Color mode toggle — only in Goals view */}
 							{viewMode === "goals" && (
 								<Button

--- a/src/0-routes/_authenticated/roster.tsx
+++ b/src/0-routes/_authenticated/roster.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useAction, useMutation } from "convex/react";
-import { RefreshCw } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMutation } from "convex/react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { RosterControls } from "@/1-components/roster/RosterControls.tsx";
 import { RosterGrid } from "@/1-components/roster/RosterGrid.tsx";
 import { ShareRosterDialog } from "@/1-components/roster/ShareRosterDialog.tsx";
-import { Button } from "@/1-components/ui/button.tsx";
 import { usePlayerDataStore } from "@/3-hooks/usePlayerDataStore.ts";
 import type { Alliance } from "@/4-lib/general/constants.ts";
 import {
@@ -24,14 +22,9 @@ export const Route = createFileRoute("/_authenticated/roster")({
 });
 
 function RosterPage() {
-	const getPlayerData = useAction(api.tacticus.actions.getPlayerData);
 	const shareRoster = useMutation(api.roster.share);
 
 	const roster = usePlayerDataStore((s) => s.roster);
-	const syncing = usePlayerDataStore((s) => s.syncing);
-	const lastSyncedAt = usePlayerDataStore((s) => s.lastSyncedAt);
-	const setPlayerData = usePlayerDataStore((s) => s.setPlayerData);
-	const setSyncing = usePlayerDataStore((s) => s.setSyncing);
 
 	const [search, setSearch] = useState("");
 	const [allianceFilter, setAllianceFilter] = useState<Alliance | "all">("all");
@@ -39,29 +32,6 @@ function RosterPage() {
 	const [viewMode, setViewMode] = useState<"faction" | "all">("faction");
 
 	const gridRef = useRef<HTMLDivElement>(null);
-
-	const handleSync = useCallback(async () => {
-		setSyncing(true);
-		try {
-			const response = await getPlayerData();
-			if (response?.player?.units) {
-				setPlayerData(response);
-			}
-		} catch {
-			// Sync failed
-		} finally {
-			setSyncing(false);
-		}
-	}, [getPlayerData, setPlayerData, setSyncing]);
-
-	// Auto-sync on mount only if store has no data
-	const didAutoSync = useRef(false);
-	useEffect(() => {
-		if (!didAutoSync.current && !lastSyncedAt) {
-			didAutoSync.current = true;
-			void handleSync();
-		}
-	}, [handleSync, lastSyncedAt]);
 
 	const enriched = useMemo(
 		() => enrichRoster(roster, CHARACTERS, MOWS),
@@ -94,24 +64,9 @@ function RosterPage() {
 					</p>
 				</div>
 
-				<div className="flex items-center gap-2">
-					<Button
-						variant="outline"
-						size="sm"
-						onClick={handleSync}
-						disabled={syncing}
-						title="Sync with Tacticus API"
-					>
-						<RefreshCw className={`size-4 ${syncing ? "animate-spin" : ""}`} />
-						<span className="hidden sm:inline">
-							{syncing ? "Syncing..." : "Sync"}
-						</span>
-					</Button>
-
-					{roster.size > 0 && (
-						<ShareRosterDialog gridRef={gridRef} onShare={handleShare} />
-					)}
-				</div>
+				{roster.size > 0 && (
+					<ShareRosterDialog gridRef={gridRef} onShare={handleShare} />
+				)}
 			</div>
 
 			{/* Controls */}

--- a/src/1-components/AppLayout.tsx
+++ b/src/1-components/AppLayout.tsx
@@ -14,6 +14,7 @@ import {
 	X,
 } from "lucide-react";
 import { useState } from "react";
+import { SyncButton } from "@/1-components/SyncButton.tsx";
 import { ThemeToggle } from "@/1-components/ThemeToggle.tsx";
 import { Button } from "@/1-components/ui/button.tsx";
 import { Separator } from "@/1-components/ui/separator.tsx";
@@ -212,6 +213,7 @@ function AuthenticatedLayout() {
 
 					{/* Right side actions */}
 					<div className="flex items-center gap-2">
+						<SyncButton />
 						<ThemeToggle />
 					</div>
 				</header>

--- a/src/1-components/SyncButton.tsx
+++ b/src/1-components/SyncButton.tsx
@@ -1,0 +1,54 @@
+import { useAction } from "convex/react";
+import { RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useRef } from "react";
+import { Button } from "@/1-components/ui/button.tsx";
+import { usePlayerDataStore } from "@/3-hooks/usePlayerDataStore.ts";
+// biome-ignore lint/correctness/useImportExtensions: Convex generated .js file
+import { api } from "~/_generated/api";
+
+export function SyncButton() {
+	const getPlayerData = useAction(api.tacticus.actions.getPlayerData);
+
+	const syncing = usePlayerDataStore((s) => s.syncing);
+	const lastSyncedAt = usePlayerDataStore((s) => s.lastSyncedAt);
+	const setPlayerData = usePlayerDataStore((s) => s.setPlayerData);
+	const setSyncing = usePlayerDataStore((s) => s.setSyncing);
+
+	const handleSync = useCallback(async () => {
+		setSyncing(true);
+		try {
+			const response = await getPlayerData();
+			if (response?.player?.units) {
+				setPlayerData(response);
+			}
+		} catch {
+			// Sync failed
+		} finally {
+			setSyncing(false);
+		}
+	}, [getPlayerData, setPlayerData, setSyncing]);
+
+	// Auto-sync once on mount if no prior sync data
+	const didAutoSync = useRef(false);
+	useEffect(() => {
+		if (!didAutoSync.current && !lastSyncedAt) {
+			didAutoSync.current = true;
+			void handleSync();
+		}
+	}, [handleSync, lastSyncedAt]);
+
+	return (
+		<Button
+			variant="ghost"
+			size="icon"
+			onClick={handleSync}
+			disabled={syncing}
+			title="Sync with Tacticus API"
+		>
+			<RefreshCw
+				className={`h-[1.2rem] w-[1.2rem] ${syncing ? "animate-spin" : ""}`}
+			/>
+			<span className="sr-only">Sync</span>
+		</Button>
+	);
+}


### PR DESCRIPTION
Centralizes the Tacticus API sync button (with auto-sync-on-mount) into a shared SyncButton component in the authenticated header, removing ~30 lines of duplicated sync logic from each of the 4 authenticated pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated data synchronization control to the centralized app header for improved accessibility.
  * Simplified individual page layouts by removing redundant sync controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->